### PR TITLE
fix items disappear

### DIFF
--- a/gamemode/core/inventory/inventory_sv.lua
+++ b/gamemode/core/inventory/inventory_sv.lua
@@ -65,8 +65,9 @@ net.Receive("gRust.DropItem", function(len, pl)
 
     local pos = pl:EyePos() + pl:GetAimVector() * 32
     local ang = pl:EyeAngles()
-
-    local item = quantity == inventory[index]:GetQuantity() and inventory[index] or inventory[index]:Split(quantity)
+    
+    local fullQuantity = inventory[index]:GetQuantity()
+    local item = quantity == fullQuantity and inventory[index] or inventory[index]:Split(quantity)
 
     local ent = gRust.CreateItemBag(item, pos, ang)
     timer.Simple(0, function()
@@ -76,5 +77,9 @@ net.Receive("gRust.DropItem", function(len, pl)
         end
     end)
     
-    inventory:Remove(index, quantity)
+    if (quantity == fullQuantity) then
+        inventory:Remove(index)
+    else
+        inventory:SyncSlot(index)
+    end
 end)


### PR DESCRIPTION
When dropping items from inventory using right-click (drop 1) or middle-click (drop half), the dropped quantity is removed twice from the inventory. For example, dropping 1 item from a stack of 100 removes 2 items total (1 dropped + 1 disappeared), or dropping half (50) removes 100 items total (50 dropped + 50 disappeared)