### PR TITLE
fix: prevent shotgun reload exceeding max clip size (#18)

### DIFF
--- a/entities/weapons/rust_shotgun.lua
+++ b/entities/weapons/rust_shotgun.lua
@@ -70,6 +70,7 @@ function SWEP:InsertShell()
 
     timer.Simple(self.InsertDelay, function()
         if (!IsValid(self)) then return end
+        if (self:Clip1() >= self.ClipSize) then return end
 
         local ammoType = self.AmmoTypes[self:GetAmmoType()]
         self:SetClip(self:Clip1() + 1)


### PR DESCRIPTION
The InsertShell timer callback could fire after Think() had already queued another insert (since Clip1() hadn't updated yet), allowing the clip to exceed ClipSize. Add a capacity guard inside the timer callback to prevent over-reload.