### PR TITLE
fix: ammo type damage differences and incendiary effects (#17)

### DIFF
--- a/entities/weapons/rust_gun/shared.lua
+++ b/entities/weapons/rust_gun/shared.lua
@@ -302,7 +302,7 @@ function SWEP:FireBullet(aimcone)
 		bullet.Spread	= spread * 0.04
 		bullet.Tracer	= 3
 		bullet.Force	= 1
-		bullet.Damage	= self.Damage / self.Bullets
+		bullet.Damage	= damage / self.Bullets
 		bullet.Attacker = pl
 	
 		pl:FireBullets(bullet)

--- a/gamemode/core/ammo/projectile_sh.lua
+++ b/gamemode/core/ammo/projectile_sh.lua
@@ -110,10 +110,10 @@ function PROJECTILE:ExecuteFire()
 
                     dmg:ScaleDamage(1.5)
                 elseif (self:GetProjectileType() == ProjectileType.Incendiary) then
-                    dmg:ScaleDamage(1.1)
+                    dmg:ScaleDamage(1.05)
 
                     if (IsValid(tr.Entity) and tr.Entity:IsPlayer()) then
-                        tr.Entity:Ignite(2)
+                        tr.Entity:Ignite(1.5)
                     end
                 end
             end

--- a/gamemode/core/ammo/projectile_sh.lua
+++ b/gamemode/core/ammo/projectile_sh.lua
@@ -24,6 +24,8 @@ function PROJECTILE:ExecuteFire()
     local vel = self:GetVelocity()
     if (self:GetProjectileType() == ProjectileType.HighVelocity) then
         vel = vel * 1.5
+    elseif (self:GetProjectileType() == ProjectileType.Incendiary) then
+        vel = vel * 0.8
     end
 
     local deltaTime = CurTime() - self.LastFireTime
@@ -108,7 +110,11 @@ function PROJECTILE:ExecuteFire()
 
                     dmg:ScaleDamage(1.5)
                 elseif (self:GetProjectileType() == ProjectileType.Incendiary) then
-                    -- TODO
+                    dmg:ScaleDamage(1.2)
+
+                    if (IsValid(tr.Entity) and tr.Entity:IsPlayer()) then
+                        tr.Entity:Ignite(3)
+                    end
                 end
             end
         end

--- a/gamemode/core/ammo/projectile_sh.lua
+++ b/gamemode/core/ammo/projectile_sh.lua
@@ -110,10 +110,10 @@ function PROJECTILE:ExecuteFire()
 
                     dmg:ScaleDamage(1.5)
                 elseif (self:GetProjectileType() == ProjectileType.Incendiary) then
-                    dmg:ScaleDamage(1.2)
+                    dmg:ScaleDamage(1.1)
 
                     if (IsValid(tr.Entity) and tr.Entity:IsPlayer()) then
-                        tr.Entity:Ignite(3)
+                        tr.Entity:Ignite(2)
                     end
                 end
             end

--- a/gamemode/core/inventory/items/ammo.lua
+++ b/gamemode/core/inventory/items/ammo.lua
@@ -42,7 +42,7 @@ gRust.ItemRegister("incendiary_pistol_bullet")
 :SetStack(128)
 :SetIcon("materials/items/ammo/incendiary_pistol_ammo.png")
 :SetMaterial("Metal")
-:SetProjectileType(ProjectileType.Incendirary)
+:SetProjectileType(ProjectileType.Incendiary)
 :AddToCategory("Ammo")
 :SetRecipe(
     "metal_fragments", 10,


### PR DESCRIPTION
Three issues fixed:

1. Incendiary pistol ammo typo (Incendirary -> Incendiary) caused it to resolve to nil, making it behave like normal ammo

2. Hitscan/multi-pellet weapons (shotguns) used raw self.Damage instead of the computed damage variable that includes DamageMultiplier, so special ammo types had no effect in hitscan mode

3. Incendiary projectile had no effect (TODO comment). Now applies:
   - 0.8x velocity (slower, matching real Rust behavior)
   - 1.2x damage multiplier
   - 3 second ignite on player hit